### PR TITLE
docs: fix `testString` example typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ const isFontListLoaded = useFontFaceObserver([
 const isFontListLoaded = useFontFaceObserver(
   [{ family: `Roboto` }],
   {
-    testString?: `ФЯЦ`,
+    testString: `ФЯЦ`,
     timeout: 5000,
   },
   {


### PR DESCRIPTION
In the README the `testString` is specified with the `?` within the usage example. I think that it's redundant there because during the runtime such code would fail. Instead, such definition could be relevant for the type definition example