### PR TITLE
feat: add explicit error in log

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,10 +66,10 @@ function useFontFaceObserver(
 
     Promise.all(promises)
       .then(() => setIsResolved(true))
-      .catch(() => {
+      .catch((e: unknown) => {
         if (showErrors) {
           // eslint-disable-next-line no-console
-          console.error(`An error occurred during font loading`)
+          console.error(`An error occurred during font loading`, e)
         }
       })
   }, [fontFacesString, testString, timeout, showErrors])


### PR DESCRIPTION
## Issue
When the `showErrors` option is opted-in, the users can only see a generic `An error occurred during font loading` message. Instead, a more informative path would be to include the error in to the log itself. As the reasons for when the promise failed could vary significantly.

## Changes Made
I added the error explicitly in the `console.error` log