### PR TITLE
chore(deps): move `react` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "fontfaceobserver": "2.1.0",
-    "react": "17.0.2"
+    "fontfaceobserver": "2.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "15.0.0",
@@ -58,6 +57,7 @@
     "lint-staged": "11.2.6",
     "microbundle": "^0.14.2",
     "prettier": "2.4.1",
+    "react": "17.0.2",
     "react-test-renderer": "17.0.2",
     "semantic-release": "18.0.0",
     "ts-jest": "27.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6377,7 +6377,7 @@ merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-microbundle@0.14.2:
+microbundle@^0.14.2:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/microbundle/-/microbundle-0.14.2.tgz#2db869c8145bd159aa55058ead47223f58f93bf2"
   integrity sha512-jODALfU3w7jnJAqw7Tou9uU8e8zH0GRVWzOd/V7eAvD1fsfb9pyMbmzhFZqnX6SCb54eP1EF5oRyNlSxBAxoag==


### PR DESCRIPTION
## Issues
This PR resolves the #147 and the #155 issues 🙌🏻 
Previously, the `react` was specified as an explicit dependency of the package. On the projects that don't use the `yarn`'s `resolutions` it could lead to an annoying exception: 
> ```
> 1. You might have mismatching versions of React and the renderer (such as React DOM)
> 2. You might be breaking the Rules of Hooks
> 3. You might have more than one copy of React in the same app
> ```

## Changes Made
I moved the `react` from the `dependencies` to the `devDependencies`. That way, it won't be included in the bundle or installed on other machines. But the package still can be developed locally.