### PR TITLE
Specify types path in package.json#exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   "umd:main": "dist/index.umd.js",
   "module": "dist/index.module.js",
   "exports": {
+    "types": "./dist/index.d.ts",
     "require": "./dist/index.js",
-    "default": "./dist/index.modern.js",
-    "types": "./dist/index.d.ts"
+    "default": "./dist/index.modern.js"
   },
   "types": "dist/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "module": "dist/index.module.js",
   "exports": {
     "require": "./dist/index.js",
-    "default": "./dist/index.modern.js"
+    "default": "./dist/index.modern.js",
+    "types": "./dist/index.d.ts"
   },
   "types": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
This fixes Typescript support with moduleResolution set to bundler

Fixes https://github.com/iamskok/use-font-face-observer/issues/169